### PR TITLE
crawling practice added

### DIFF
--- a/custom_image/Dockerfile
+++ b/custom_image/Dockerfile
@@ -1,0 +1,12 @@
+FROM apache/airflow:2.7.3
+USER root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+         vim \
+  && apt-get autoremove -yqq --purge \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+USER airflow
+RUN pip install apache-airflow-providers-mongo
+RUN pip install beautifulsoup4 requests selenium
+RUN pip uninstall -y argparse

--- a/dags/dag_mongo_test.py
+++ b/dags/dag_mongo_test.py
@@ -1,0 +1,45 @@
+from airflow import DAG
+import pendulum
+from airflow.operators.python import PythonOperator
+from airflow.providers.mongo.hooks.mongo import MongoHook
+from datetime import timedelta
+import json
+
+def on_failure_callback(**context):
+    print(f"Task {context['task_instance_key_str']} failed.")
+
+with DAG(
+    dag_id="dag_mongo_test",
+    schedule=None,
+    start_date=pendulum.datetime(2024, 1, 1, tz="Asia/Seoul"),
+    catchup=False,
+    tags=["practice", "mongo"],
+    default_args={
+        "owner": "Kay",
+        "retries": 2,
+        "retry_delay": timedelta(minutes=5),
+        "on_failure_callback": on_failure_callback
+    }
+) as dag:
+    def upload_to_mongo(ti, **context):
+        try:
+            hook = MongoHook(conn_id="edu_mongo")
+            client = hook.get_conn()
+            test_db = hook.get_collection(mongo_collection="test_data")
+            print(f"Connected to MongoDB - {client.server_info()}")
+            test_db.insert_one(context["test_dict"])
+        except Exception as e:
+            print(f"Error connecting to MongoDB -- {e}")
+
+    t1 = PythonOperator(
+        task_id="upload-mongodb",
+        python_callable=upload_to_mongo,
+        op_kwargs={
+            "test_dict": {
+                "test_key1": 1,
+                "test_key2": "test_value"
+                }
+        },
+    )
+
+    t1

--- a/dags/dag_thumbnail_picker.py
+++ b/dags/dag_thumbnail_picker.py
@@ -21,43 +21,146 @@ with DAG(
     # - 데이터베이스에 저장
     # - 뷰 / 업로드 시간
     # - TOP 5 찾기
-    def crawl(url):
+
+    # Objective : Crawl thumbnail, title, views, and hours_uploaded from youtube and push them to xcom
+    # Input : url
+    # Output : -
+    def crawl(ti, url, name, **kwargs):
         import time
         from selenium import webdriver
         from selenium.webdriver.common.by import By
         from selenium.webdriver.common.keys import Keys
+        from datetime import datetime
+        import pytz
 
-        browser = webdriver.Chrome()
-        browser.get(url)
+        uploaded_at_stamps = {
+            "second": 1 / (60 * 60),
+            "seconds": 1 / (60 * 60),
+            "minute": 1 / 60,
+            "minutes": 1 / 60,
+            "hour": 1,
+            "hours": 1,
+            "day": 24,
+            "days": 24,
+            "week": 24 * 7,
+            "weeks": 24 * 7,
+            "month": 24 * 30,
+            "months": 24 * 30,
+            "year": 24 * 30 * 365,
+            "years": 24 * 30 * 365
+        }
 
-        elements = browser.find_element(By.CSS_SELECTOR, "body")
+        options = webdriver.ChromeOptions()
+        options.add_argument('--disable-gpu')
+        options.add_argument('--no-sandbox')
+        options.add_argument('--disable-setuid-sandbox')
+        options.add_argument('--disable-dev-shm-usage')
+        options.add_argument("--start-maximized")
+        options.add_argument("--window-size=1920,1080")
+        driver = webdriver.Remote(command_executor="http://remote_chromedriver:4444/wd/hub", options=options)
+        # with webdriver.Remote(command_executor="http://remote_chromedriver:4444/wd/hub", options=options) as driver:
+        print(url)
+    
+        driver.get(url)
+        action = driver.find_element(By.CSS_SELECTOR, "body")
+        reached_bottom = False
+        scrollY_old = 0
+        while not reached_bottom:
+            action.send_keys(Keys.END)
+            time.sleep(2)
+            scrollY_new = driver.execute_script("scrollY")
+            if scrollY_new == scrollY_old:
+                reached_bottom = True
+            else:
+                scrollY_old = scrollY_new
         
-        thumbnail_urls, uploaded_ats, views = [], [], []
-        scroll_down = True
-        scrollY_before = 1
-        while scroll_down:
-            scrollY_now = browser.execute_script("return document.scrollY")
-        return
+        thumbnail_elements = driver.find_elements(By.CSS_SELECTOR, '.yt-core-image')
+        aria_label_elements = driver.find_elements(By.CSS_SELECTOR, "#video-title")
+        thumbnail_list, raw_label_list, title_list, views_list, hours_uploaded_list = [], [], [], [], []
+        for i, thumbnail_element in enumerate(thumbnail_elements):
+            thumbnail_list.append(thumbnail_element.get_attribute("src"))
+            raw_label = aria_label_elements[i].get_attribute("aria-label")
+            raw_label_list.append(raw_label)
+            label_splited = raw_label.split("by")
+            title = label_splited[0].strip()
+            title_list.append(title)
+
+            # 2번째 레이블 문자열에서 views, uploaded at을 구해야함
+            supplementary_label_splited = label_splited[1].split(" ")
+            # 1. views 는 views 앞의 숫자. 쉼표는 제거한 다음, 숫자로 변환해야 함.
+            views_idx = supplementary_label_splited.index("views") - 1
+            views = int(supplementary_label_splited[views_idx].replace(",", ""))
+            views_list.append(views)
+            # 2. uploaded 는 second/seconds/minute/minutes/hour/hours/day/days/month/months/year/years ago 앞의 숫자를 구한 다음 시간으로 변환해야 함.
+            time_unit_idx = supplementary_label_splited.index("ago") - 1
+            time_idx = time_unit_idx - 1
+            hours_uploaded = float(supplementary_label_splited[time_idx]) * uploaded_at_stamps[supplementary_label_splited[time_unit_idx]]
+            hours_uploaded_list.append(hours_uploaded)
+            time_today = datetime.now(pytz.timezone("Asia/Seoul"))
+            date_today = time_today.strftime("%Y%m%d")
+            
+            ti.xcom_push(key="channel_owner_name", value=name)
+            for i, title in enumerate(title_list):
+                thumbnail = thumbnail_list[i]
+                views = views_list[i]
+                hours_uploaded = hours_uploaded_list[i]
+                ti.xcom_push(
+                    key=f"video_{i + 1}", 
+                    value = {
+                        "title": title,
+                        "thumbnail": thumbnail,
+                        "views": views,
+                        "hours_uploaded": hours_uploaded,
+                        "document_created_at": date_today
+                    }
+                )
+            ti.xcom_push(key="total_number_of_videos", value=len(title_list))
+        print("xcom migration completed.")
     
-    def save_in_mongo():
-        return
-    
+    # Objective : create new document if a document with the thumbnail and title does not exist. If there is a document with the thumbnail and title, edit views and hours uploaded
+    # Input : -
+    # Output : log
+    def save_in_mongo(ti):
+        hook = MongoHook(conn_id="edu_mongo")
+        client = hook.get_conn()
+        youtube_data_table = hook.get_collection(mongo_collection="youtube_data")
+        print(f"Connected to MongoDB - {client.server_info()}")
+
+        total_number_videos = ti.xcom_pull(key="total_number_of_videos", task_ids="task_crawl")
+        creator_name = ti.xcom_pull(key="channel_owner_name", task_ids="task_crawl")
+        for i in range(total_number_videos):
+            video_info = ti.xcom_pull(key=f"video_{i + 1}", task_ids="task_crawl")
+            video_info["creator"] = creator_name
+            youtube_data_table.insert_one(video_info)
+        
     def get_view_per_hour():
         return
 
     def get_top_five():
         return
 
-    task_test1 = BashOperator(
-        task_id="task_test1",
-        bash_command="echo ping"
+    # task_test1 = BashOperator(
+    #     task_id="task_test1",
+    #     bash_command="echo ping"
+    # )
+
+    # task_test2 = BashOperator(
+    #     task_id="task_test2",
+    #     bash_command="echo pong"
+    # )
+
+    task_crawl = PythonOperator(
+        task_id="task_crawl",
+        python_callable=crawl,
+        op_kwargs={
+            "url": "https://www.youtube.com/@user-yy5dx4lm9o/videos",
+            "name": "나니의 연대기"
+        }
     )
 
-    task_test2 = BashOperator(
-        task_id="task_test2",
-        bash_command="echo pong"
+    task_mongo_create = PythonOperator(
+        task_id="task_mongo_create",
+        python_callable=save_in_mongo,
     )
 
-
-
-    task_test1 >> task_test2
+    task_crawl >> task_mongo_create

--- a/dags/dag_thumbnail_picker.py
+++ b/dags/dag_thumbnail_picker.py
@@ -1,0 +1,63 @@
+from airflow import DAG
+import pendulum
+from airflow.operators.python import PythonOperator
+from airflow.operators.bash import BashOperator
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.providers.mongo.hooks.mongo import MongoHook
+from bs4 import BeautifulSoup
+import requests
+
+with DAG(
+    dag_id="dag_thumbnail_picker",
+    schedule="0 10 * * *",
+    start_date=pendulum.datetime(2024, 1, 1, tz="Asia/Seoul"),
+    catchup=False,
+    description="특정 유튜브 채널의 비디오들의 썸네일(thumbnail_url), 업로드 날짜(uploaded_at), 뷰(views)를 크롤링해서 저장한다. "
+) as dag:
+    # 필요한 함수들
+    # - 무한 스크롤
+    # - 크롤링(썸네일, 제목, 업로드 날짜, 뷰)
+    # - 데이터베이스에 저장
+    # - 뷰 / 업로드 시간
+    # - TOP 5 찾기
+    def crawl(url):
+        import time
+        from selenium import webdriver
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.common.keys import Keys
+
+        browser = webdriver.Chrome()
+        browser.get(url)
+
+        elements = browser.find_element(By.CSS_SELECTOR, "body")
+        
+        thumbnail_urls, uploaded_ats, views = [], [], []
+        scroll_down = True
+        scrollY_before = 1
+        while scroll_down:
+            scrollY_now = browser.execute_script("return document.scrollY")
+        return
+    
+    def save_in_mongo():
+        return
+    
+    def get_view_per_hour():
+        return
+
+    def get_top_five():
+        return
+
+    task_test1 = BashOperator(
+        task_id="task_test1",
+        bash_command="echo ping"
+    )
+
+    task_test2 = BashOperator(
+        task_id="task_test2",
+        bash_command="echo pong"
+    )
+
+
+
+    task_test1 >> task_test2

--- a/testings/test_crawl.py
+++ b/testings/test_crawl.py
@@ -7,6 +7,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 
 url_bighead = "https://www.youtube.com/@bighead033/videos"
 url_nani = "https://www.youtube.com/@user-yy5dx4lm9o/videos"
+url_gcl = "https://www.youtube.com/@GCL/videos"
 uploaded_at_stamps = {
     "second": 1 / (60 * 60),
     "seconds": 1 / (60 * 60),
@@ -16,6 +17,8 @@ uploaded_at_stamps = {
     "hours": 1,
     "day": 24,
     "days": 24,
+    "week": 24 * 7,
+    "weeks": 24 * 7,
     "month": 24 * 30,
     "months": 24 * 30,
     "year": 24 * 30 * 365,
@@ -23,10 +26,10 @@ uploaded_at_stamps = {
 }
 
 browser = webdriver.Chrome(service=ChromeService(ChromeDriverManager().install()))
-browser.get(url_nani)
+browser.get(url_gcl)
 action = browser.find_element(By.CSS_SELECTOR, "body")
 reached_bottom = False
-scrollY_old, scrollY_new = 0, 0
+scrollY_old = 0
 
 # 스크롤 끝까지
 while not reached_bottom:

--- a/testings/test_crawl.py
+++ b/testings/test_crawl.py
@@ -26,7 +26,11 @@ uploaded_at_stamps = {
 }
 
 browser = webdriver.Chrome(service=ChromeService(ChromeDriverManager().install()))
-browser.get(url_gcl)
+# options = webdriver.ChromeOptions()
+# options.add_argument("--ignore-ssl-errors=yes")
+# options.add_argument("--ignore-certificate-errors")
+# browser = webdriver.Remote(command_executor="http://localhost:4444/wd/hub", options=options)
+browser.get(url_nani)
 action = browser.find_element(By.CSS_SELECTOR, "body")
 reached_bottom = False
 scrollY_old = 0
@@ -35,7 +39,7 @@ scrollY_old = 0
 while not reached_bottom:
     action.send_keys(Keys.END)
     time.sleep(2)
-    scrollY_new = browser.execute_script("return scrollY")
+    scrollY_new = browser.execute_script("scrollY")
 
     if scrollY_new == scrollY_old:
         reached_bottom = True
@@ -51,7 +55,6 @@ for i, thumbnail_element in enumerate(thumbnail_elements):
     raw_label = aria_label_elements[i].get_attribute("aria-label")
     raw_label_list.append(raw_label)
 
-    raw_label_list.append(raw_label)
     label_splited = raw_label.split("by")
     title = label_splited[0].strip()
     title_list.append(title)

--- a/testings/test_crawl.py
+++ b/testings/test_crawl.py
@@ -1,0 +1,75 @@
+import time
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.service import Service as ChromeService
+from webdriver_manager.chrome import ChromeDriverManager
+
+url_bighead = "https://www.youtube.com/@bighead033/videos"
+url_nani = "https://www.youtube.com/@user-yy5dx4lm9o/videos"
+uploaded_at_stamps = {
+    "second": 1 / (60 * 60),
+    "seconds": 1 / (60 * 60),
+    "minute": 1 / 60,
+    "minutes": 1 / 60,
+    "hour": 1,
+    "hours": 1,
+    "day": 24,
+    "days": 24,
+    "month": 24 * 30,
+    "months": 24 * 30,
+    "year": 24 * 30 * 365,
+    "years": 24 * 30 * 365,
+}
+
+browser = webdriver.Chrome(service=ChromeService(ChromeDriverManager().install()))
+browser.get(url_nani)
+action = browser.find_element(By.CSS_SELECTOR, "body")
+reached_bottom = False
+scrollY_old, scrollY_new = 0, 0
+
+# 스크롤 끝까지
+while not reached_bottom:
+    action.send_keys(Keys.END)
+    time.sleep(2)
+    scrollY_new = browser.execute_script("return scrollY")
+
+    if scrollY_new == scrollY_old:
+        reached_bottom = True
+    else:
+        scrollY_old = scrollY_new
+
+thumbnail_elements = browser.find_elements(By.CSS_SELECTOR, '.yt-core-image')
+aria_label_elements = browser.find_elements(By.CSS_SELECTOR, "#video-title")
+
+thumbnail_list, raw_label_list, title_list, views_list, hours_uploaded_list = [], [], [], [], []
+for i, thumbnail_element in enumerate(thumbnail_elements):
+    thumbnail_list.append(thumbnail_element.get_attribute("src"))
+    raw_label = aria_label_elements[i].get_attribute("aria-label")
+    raw_label_list.append(raw_label)
+
+    raw_label_list.append(raw_label)
+    label_splited = raw_label.split("by")
+    title = label_splited[0].strip()
+    title_list.append(title)
+
+    # 2번째 레이블 문자열에서 views, uploaded at을 구해야함
+    supplementary_label_splited = label_splited[1].split(" ")
+    # 1. views 는 views 앞의 숫자. 쉼표는 제거한 다음, 숫자로 변환해야 함.
+    views_idx = supplementary_label_splited.index("views") - 1
+    views = int(supplementary_label_splited[views_idx].replace(",", ""))
+    views_list.append(views)
+
+    # 2. uploaded 는 second/seconds/minute/minutes/hour/hours/day/days/month/months/year/years ago 앞의 숫자를 구한 다음 시간으로 변환해야 함.
+    time_unit_idx = supplementary_label_splited.index("ago") - 1
+    time_idx = time_unit_idx - 1
+    hours_uploaded = float(supplementary_label_splited[time_idx]) * uploaded_at_stamps[supplementary_label_splited[time_unit_idx]]
+    hours_uploaded_list.append(hours_uploaded)
+
+
+print(thumbnail_list)
+print(raw_label_list)
+print(title_list)
+print(views_list)
+print(hours_uploaded_list)
+


### PR DESCRIPTION
# 회고록
## 240101
- 크롤링 댁을 만들기 전에 selenium으로 크롤링하는 방법을 익히기 위해서 단일 py 파일로 크롤링을 시도해 보았다.
- 알아낸 점
1. selenium 은 시뮬레이터처럼 실제로 브라우저를 돌리면서 스크레이핑을 하는 방식이기 때문에 사람이 크롬을 사용하는 것과 같은 환경이 필요하고, 그렇기 때문에 google-chrome-stable과 그와 같은 버전의 chromedriver가 필요하다. 처음에 webdriver_manager.chrome만 쓰면 설치 안 해도 되는 줄 알고 사용했는데 webdriver_manager.chrome은 크롬이 설치된 디렉토리 패스를 알아서 찾아주는 패키지일 뿐 크롬을 대신해주는 패키지는 아니였다.

2. selenium module
   - webdriver.Chrome(service= Service(ChromeDriverManager.install()))) : 크롬 브라우저 열기
   - browswer.get(url) : 브라우저에서 해당 url을 로딩
   - browser.find_element(By.***, "~~~") : 현재 브라우저의 HTML에서 "~~~"과 동일한 내용을 가진 ***을 찾는다.
   - browser.execute_script("script~~~") : 현재 브라우저에서 개발자 툴 콘솔에 명령어를 수행시킨다.
   - .send_keys(Keys.*) : * 키를 입력한다.
   - ELEMENT.get_attribute("===") : 해당 ELEMENT에서 === 아트리뷰트의 내용을 추출한다.
   - ELEMENT.text : 해당 element로 감싸진 문자열(JSX)을 추출한다.

3. 무한 스크롤
   - 무한 스크롤이 적용되어 있는 경우 스크롤이 화면 하단에 닿지 않는 이상 다음 아이템들이 다운로드되지 않으므로, 아이템이 다 로딩될 때까지 끝까지 Key.END로 내려주고 스크레이핑을 시작하는 것이 중요하다. 스크롤 사이 사이 time.sleep으로 쉬어주는 것도 중요하며, 언제 무한 스크롤의 끝에 도달했는지를 알아낼 힌트를 찾아야한다. 사이트마다 다르겠지만 구글에서 찾아본 바로는 document.body.scrollHeight를 사용해서 스크롤바의 길이가 더이상 변하지 않으면 무한 스크롤이 끝난다는 의미니까 이전 스크롤 행위 떄의 스크롤바 길이와 후의 스크롤바 길이가 같다면 스크롤 룹을 멈추는 방식을 사용하라는데 유튜브는 scrollHeight가 없었다. 그래서 비슷한 느낌으로다가 scrollY를 사용해서 스크롤 바 위치가 더이상 이동하지 않으면 스크롤을 그만 내리는 방식으로 대체했다.

4. Selector
   - selector를 만들 때 보통 class에서 반복되는 단어 앞에 .을 붙이거나, id 앞에 #을 붙여서 CSS_SELECTOR로 찾아 스크레이핑을 할 수 있다. 
   - 내가 추출하려는 정보는 썸네일 사진, 영상 제목, 뷰 수, 업로드되어 있던 시간이였는데 셀렉터로 막 뽑던 중에 제목을 뽑으려고 셀렉해놨던 aria-label에 썸네일 빼고 모든 정보가 들어가 있다는 것을 알았다. 그래서 여러번 스크래핑하는 대신 이 문자열을 파싱해서 데이터를 추출하는 방향으로 틀었다.

5. 시간
   - 유튜브는 업로드되어 있던 시간을 "n days ago", "n months ago" 등의 숫자 + 문자 형태로 시간을 알려준다. 나는 단위를 시간으로 통일할 것이기 때문에 dictionary에 모든 시간 관련 단위를 적은 다음 얼마를 곱해야 시간으로 변환되는지 적어 모든 업로드 시간을 시간 단위로 변환하였다.

## 20240103
- 1월 1일과 1월 2일 내내 mongoDB와 씨름을 했고 드디어 완벽히 airflow와 mongoDB 사이에서 DB I/O를 수행할 수 있게 되었다
- 알아낸 점
1. MongoHook
   - MongoHook을 사용하여 Connections에 저장해 놓은 mongo DB connection id에 접근하여 I/O를 수행하려고 구글링을 했을 때, MongoHook 개체를 생성하고 mongo_conn_id 라는 argument로 connection_id를 특정하여 커넥션을 구성하라는 글을 보고 시작했다. 그러나, 계속 버그가 나타났는데 특이한 점이 버그에 따르면 내가 conn_id로 어떤 값을 주던 간에 mongo_default로 인식이 된다는 점이였다. 그래서 처음에는 그냥 connection_id를 mongo_default로 줘보고 주먹구구식으로 진행했는데 이떄는 또 내가 host랑 schema를 잘못 저장해놔서 커넥션이 제대로 구성되지 않았다. 그러던 중에 MongoHook 모듈 자체를 훑어보기 위해서 모듈 자체를 읽어봤는데 여기서 왜 conn_id가 제대로 인식이 안되는지 알아내었다. 버전 차이 때문인지, 아니면 그냥 튜토리얼이 틀렸는지는 모르겠으나, parameter 이름이 mongo_conn_id가 아니라 conn_id였다. 그리고 호스트 정보는 connection uri에서 @ 뒤에 위치한 부분을 저장해야 한다.

2. seleniumHQ
   - selenium/standalone-chrome : 앞서 기록해둔 것처럼 셀레니움은 실제 브라우저에서 사람이 로딩시키는 것처럼 페이지를 다 렌더링시킨 다음 HTML을 파싱해서 스크레이핑을 하던, 매크로 행위를 수행시키던 하는 방식이다. 그래서, 실제 구동되는 브라우저가 필요하다. 처음에는 크롬이랑 크롬 드라이버를 airflow worker container에 설치해야하나? 라는 생각이 있었는데, 그건 좀 말이 안되는 거 같았다. 크롬이랑 크롬드라이버가 무거운 프로그램들이기도 하고, 크몽만 보더라도 15페이지가 넘어가고 외국 아웃소싱 사이트로 가면 훨씬 더 많을정도로 크롤러 시장이 큰데, 이런 주먹구구식의 방식이 아닌 더 간단하고 스마트하게 할 수 있는 방법이 있을 거 같았다. 그 결과 찾아낸 것이 docker image였다. 처음에는 selenium/standalone-chrome이라는 가상 크롬/크롬 드라이버를 돌릴 수 있는 이미지를 컨테이너라이즈해서 포트를 열어놓으면 될 줄 알았다. 근데 아니였다. 아마 airflow worker에서 액세스 할 수 없어서 그런 듯했다. 그래서 다른 방법을 찾아보았는데, airflow container 내에 selenium을 세팅하는 방법이였다, 그 결과, airflow로 셀레니움을 사용하여 스크레이핑하는 방법을 찾아내었다. 그러나, 이게 다가 아니였다.
   -  세션 : 개발 중에는 try & error을 많이 사용한다. 적어보고, 수행시켜보고, 내가 바라는대로 수행하면 굿, 아니면 수정, 이런 방식을 많이 사용하는데, 셀레니움이 엮여있으니까 문제가 있었다. 셀레니움HQ 특성 상, 드라이버를 생성할 때 세션을 하나 만들어서 거기서 브라우저를 구동시키고 스크레이핑을 진행하는데 가장 기본 세팅으로 컨테이너를 구성해놓으니까 세션은 하나뿐이고, 세션에서 할 일이 끝났는데도 세션이 꺼지질 않아서 다음 시도를 해보려고 하면 바로 구동되지 않고 대기열(queue)에 걸려있는 상황이 계속 생겼다. 그래서, 처음에는 드라이버를 없애는 방법을 생각했는데, 생각해보니까 드라이버를 없애는 거랑 세션을 종료하는 거랑 별개의 문제였다. 그래서 근본적인 부분인 docker compose 부분을 어떻게 건드리면 되지 않으려나라는 생각으로 찾아보았는데, 아니나 다를까 있었다. 동시에 켜질 수 있는 세션 개수, 세션 자동 종료 시간 등을 설정할 수 있어서 세션 개수를 5개로 하고, 세션 자동 종료를 60초로 설정하여 회전율을 빠르게 설정했다. 근데 또 문제가 있었다. 자꾸 브라우저가 무너지는 버그가 있었는데, 이건 셀레니움이 구동되는 환경의 문제였다. 메모리가 부족해서 크롬 브라우저가 충돌로 강제 종료되는 상황이였는데, webdriver option으로 diable-dev-shm-usage를 주어, 더 큰 메모리를 사용할 수 있게 강제하여 해결하였다. 
   - Xcom : airflow에는 Task 간에 공유할 수 있는 데이터를 잠깐 저장할 수 있는 곳이 있는데 이게 바로 xcom이다. 어차피 정형 데이터라 용량도 그리 크지 않고, 이번 프로젝트의 포인트는 DB I/O와 크롤링이 중점이였기 떄문에 DB 스키마에 대한 고민이나, 데이터의 흐름에 큰 시간을 쏟지 않고 해결하기 위해 raw data만 DB에 저장하고 나머지는 다 xcom으로 해결하였다.
   - webdriver.execute_script() : 다 해결된 줄 알았는데 이상한 게 있었다. 영상이 분명히 100개가 넘는 채널의 영상을 크롤링하는데 영상이 88개까지만 스크레이핑 되는 것이였다. 무한 스크롤이 끝까지 내려가지지 않는 것이였다. 그래서 확인해본 결과 scrollY 값이 무한 스크롤이 끝나기도 전에 None 값으로 바껴 중간에 멈추는 것이 문제였다. 그래서, return scrollY로 스크립트 값을 바꿔주니 해결되었다.

- 아직 해결 못한 문제 :
   1. 영상이 많을 시(2000개 이상) 끝까지 스크롤되지 않는다 => 메모리 문제인듯?
   2. 직렬 처리에서 병렬 처리로 바꿔야 스크레이핑 작업이 좀 빨라질 것 같다.(현재 한 1300개 긁어오는데 1시간 40분) => 병렬처리및 테스크 세분화 필요